### PR TITLE
Return Raw Apple Pay Response

### DIFF
--- a/src/applepay.js
+++ b/src/applepay.js
@@ -94,7 +94,7 @@ export class ApplePay {
                 });
 
             // return success
-            return { status: "success", token: token };
+            return { status: "success", token: token, raw_response: response };
         } catch (err) {
             // return fail
             return { status: "fail", error: err.message };


### PR DESCRIPTION
We would like to be able to capture the Apple Pay payment method's `displayName`, which is contained in the response from the Apple Pay sheet.

https://developer.apple.com/documentation/apple_pay_on_the_web/applepaypaymentmethod/1916110-displayname

It is contained in the `response` variable at:

```js
response.details.token.paymentMethod.displayName
```

This is helpful for our customers as it reflects the brand name and last 4 digits of their actual card, and not the card number associated with the device (which end users generally do not recognize).

Would you be open to returning the entire response object as proposed here? Or some other version of this? I'm happy to make changes!