### PR TITLE
Add Additional Google Pay Request Objects

### DIFF
--- a/src/googlepay.js
+++ b/src/googlepay.js
@@ -39,7 +39,9 @@ export class GooglePay {
         type: "CARD",
         parameters: {
           allowedAuthMethods: this.settings.allowedCardAuthMethods,
-          allowedCardNetworks: this.settings.allowedCardNetworks
+          allowedCardNetworks: this.settings.allowedCardNetworks,
+          billingAddressRequired: this.settings.billingAddressRequired,
+          billingAddressParameters: this.settings.billingAddressParameters
         }
       };
 
@@ -169,6 +171,7 @@ export class GooglePay {
   addGooglePayButton() {
     const paymentsClient = this.getGooglePaymentsClient();
     const button = paymentsClient.createButton({
+      buttonType: this.settings.buttonType,
       onClick: this.onGooglePaymentButtonClicked.bind(this)
     });
     this.settings.container.appendChild(button);


### PR DESCRIPTION
We would like to be able to pass in additional objects into Google Pay. These include
- billingAddressRequired
- billingAddressParameters
- buttonType

Currently google pay defaults to `buttonType` of `Buy`, if nothing is passed in. Since most of our customers are donating, we would like to control the buttonType and set it as `donate` or `pay`.

Google Pay Card Parameters:
https://developers.google.com/pay/api/web/reference/request-objects#CardParameters

Google Pay Button Options:
https://developers.google.com/pay/api/web/reference/request-objects#ButtonOptions

Example of these additional objects used within `settings` of walletjs :
https://sandbox.fluidpay.com/docs/walletjs/#step-2-add-javascript-file

```
const settings = {
  container: '#container',
  merchantName: 'Example Merchant',
  merchantId: '12345678901234567890',
  gatewayMerchantId: '<PUBLIC_API_KEY>',
  allowedCardNetworks: ['VISA'],
  allowedCardAuthMethods: ['PAN_ONLY'],
  transactionInfo: {
      countryCode: 'US',
      currencyCode: 'USD',
      totalPrice: '1.23'
  },
  billingAddressRequired: true,
  billingAddressParameters: {
    format: "FULL",
  },
  buttonType: 'donate',
  onGooglePaymentButtonClicked: paymentDataRequest => {
    paymentDataRequest
      .then(paymentData => {
          // Get the token.
          const token = paymentData.paymentMethodData.tokenizationData.token

          // Send the token to your backend server, which will
          // then call our API to create a new transaction with
          // the token set as the payment method.
      }).catch(err => {
          console.log(err)
      })
  }
}
```